### PR TITLE
Fixes README.md for `backend-api-demo`

### DIFF
--- a/backend-api-demo/README.md
+++ b/backend-api-demo/README.md
@@ -1,4 +1,4 @@
-# Pendle Limit Order API Demo
+# Pendle Backend API Demo
 
 This repository is designed for developers seeking to interact with Pendle Backend using TypeScript. 
 
@@ -10,7 +10,7 @@ The demo project demonstrates how to
 
 ## Getting Started
 To run examples:
-- Change directory to the demo project folder: `cd limit-order-api-demo`
+- Change directory to the demo project folder: `cd backend-api-demo`
 - Install required dependencies with `npm install`
 - Execute the index.ts file using `npm run start`
 


### PR DESCRIPTION
## Pull Request Description

### Summary
This pull request updates the `backend-api-demo/README.md` file to correct directory and project naming inconsistencies. The previous README referred to the demo as "Pendle Limit Order API Demo" and instructed users to navigate to the `limit-order-api-demo` directory, which was inaccurate. These references have now been updated to "Pendle Backend API Demo" and `backend-api-demo`, respectively.

### Details of the Fix
- **Project Title:** Changed from "Pendle Limit Order API Demo" to "Pendle Backend API Demo" in the README header.
- **Directory Reference:** Updated the "Getting Started" section to instruct users to change directories into `backend-api-demo` instead of `limit-order-api-demo`.

### Reason for the Change
The README previously contained outdated references to the old project name and directory structure. This could cause confusion for developers trying to follow the setup instructions, potentially leading to errors or wasted time. The changes ensure the documentation accurately reflects the current project structure and naming conventions.

### Impact
- Improves clarity and accuracy of project documentation.
- Reduces onboarding friction for new contributors and users.
- No changes were made to code or functionality—this PR affects documentation only.

### Checklist
- [x] Documentation updated to match current project structure.
- [x] No code or configuration changes included.
- [x] Ready for review.

Please let me know if further clarification or additional changes are needed.